### PR TITLE
Able to set all collection properties when creating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## Added
+Ability to set the `list`, `default` and `array` properties when creating a new collection. | [Issue #20](https://github.com/streamlux/vscode-appwrite/issues/20) | [PR #21](https://github.com/streamlux/vscode-appwrite/pull/21) | Thanks [@Maatteogekko](https://github.com/Maatteogekko)!
+
 ## [0.1.1] - 2021-5-31
 ## Added
 - You can now easily create function tags from multiple places in the extension. [PR #19](https://github.com/streamlux/vscode-appwrite/pull/19)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-appwrite",
     "displayName": "Appwrite",
     "description": "Manage your Appwrite resources right from VS Code!",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "engines": {
         "vscode": "^1.55.0"
     },

--- a/src/appwrite.d.ts
+++ b/src/appwrite.d.ts
@@ -276,7 +276,7 @@ export type CollectionsList = {
     collections: Collection[];
 };
 
-export type CreatedRule = Omit<Rule, "$id" | "$collection" | "default" | "list">;
+export type CreatedRule = Omit<Rule, "$id" | "$collection">;
 
 export type Rule = {
     $id: string;
@@ -284,10 +284,10 @@ export type Rule = {
     type: string;
     key: string;
     label: string;
-    default: string;
-    array: boolean;
+    default?: any;
     required: boolean;
-    list: string[];
+    array: boolean;
+    list?: string[];
 };
 
 export type Permissions = {

--- a/src/commands/database/createRule.ts
+++ b/src/commands/database/createRule.ts
@@ -10,15 +10,13 @@ export async function createRule(rulesTreeItem: RulesTreeItem): Promise<void> {
         return;
     }
 
-    const ruleContext = await createRuleWizard();
     const collection = rulesTreeItem.parent.collection;
+    const ruleContext = await createRuleWizard(collection);
 
     if (ruleContext) {
         const newRule: CreatedRule = {
             ...ruleContext,
             type: ruleContext.type,
-            required: true,
-            array: false,
         };
 
         databaseClient.createRule(collection, newRule);

--- a/src/ui/createRuleWizard.ts
+++ b/src/ui/createRuleWizard.ts
@@ -1,41 +1,18 @@
 import { QuickPickItem, window } from "vscode";
+import { Collection, CollectionsList } from "../appwrite";
+import { client } from "../client";
+import { AppwriteSDK } from "../constants";
+import AppwriteCall from "../utils/AppwriteCall";
 
 export type CreateRuleWizardContext = {
     label: string;
     key: string;
     type: keyof typeof ruleTypes;
+    default: any;
+    required: boolean;
+    array: boolean;
+    list?: string[];
 };
-
-export async function createRuleWizard(): Promise<CreateRuleWizardContext | undefined> {
-    const label = await window.showInputBox({
-        placeHolder: "Label",
-        prompt: "Attribute internal display name",
-    });
-    if (label === undefined) {
-        return;
-    }
-    const key = await window.showInputBox({
-        placeHolder: "Key",
-        prompt: "Attribute key name. Used as the document JSON key in the Database API.",
-    });
-    if (key === undefined) {
-        return;
-    }
-    const ruleTypeItems: QuickPickItem[] = Object.entries(ruleTypes).map(([label, description]) => ({
-        label,
-        description,
-    }));
-
-    const type = await window.showQuickPick(ruleTypeItems);
-
-    if (type === undefined) {
-        return;
-    }
-    if (label && key && type) {
-        return { label, key, type: (type.label as unknown) as keyof typeof ruleTypes };
-    }
-    return undefined;
-}
 
 const ruleTypes = {
     text: "Any string value.",
@@ -45,6 +22,119 @@ const ruleTypes = {
     url: "Any valid URL.",
     email: "Any valid email address.",
     ip: "Any valid IP v4 or v6 address.",
-    document:
-        "Accept a valid child document. When using this type you are also required to pass the 'list' parameter with an array of the collections UID values of the document types you want to accept.",
+    document: "Accept a valid child document from specified collection(s).",
 };
+
+type RuleType = keyof typeof ruleTypes;
+
+export async function createRuleWizard(collection: Collection): Promise<CreateRuleWizardContext | undefined> {
+    const label = await window.showInputBox({
+        placeHolder: "Attribute label",
+        prompt: "Attribute internal display name",
+        validateInput: (value) => {
+            if (value === "") {
+                return "Label cannot be empty.";
+            }
+        },
+    });
+    if (label === undefined) {
+        return;
+    }
+    const key = await window.showInputBox({
+        placeHolder: "Attribute key name",
+        prompt: "Attribute key name. Used as the document JSON key in the Database API.",
+        ignoreFocusOut: true,
+        validateInput: (value) => {
+            if (value === "") {
+                return "Key name cannot be empty.";
+            }
+        },
+    });
+    if (key === undefined) {
+        return;
+    }
+    const ruleTypeItems: QuickPickItem[] = Object.entries(ruleTypes).map(([label, description]) => ({
+        label,
+        detail: description,
+    }));
+
+    const typeItem = await window.showQuickPick(ruleTypeItems, { placeHolder: "Rule value type." });
+    const type: RuleType | undefined = (typeItem?.label as RuleType) ?? undefined;
+
+    if (typeItem === undefined || type === undefined) {
+        return;
+    }
+
+    let list: string[] | undefined = undefined;
+
+    if (type === "document") {
+        const databaseSdk = new AppwriteSDK.Database(client);
+        const collectionsList = await AppwriteCall<CollectionsList, CollectionsList>(databaseSdk.listCollections());
+
+        if (collectionsList === undefined) {
+            window.showErrorMessage("Could not get collections list.");
+            return;
+        }
+
+        if (collectionsList) {
+            const collections = collectionsList.collections.filter((c) => c.$id !== collection.$id);
+            const qpItems: QuickPickItem[] = collections.map((collection) => ({
+                label: collection.name,
+                description: collection.$id,
+            }));
+
+            const listInput = await window.showQuickPick(qpItems, {
+                canPickMany: true,
+                placeHolder: "Collections which contain valid child documents for this document attribute.",
+                ignoreFocusOut: true,
+            });
+            list = listInput?.map((item) => item.description as string) ?? [];
+        }
+    }
+
+    if (label === "document" && list === undefined) {
+        return;
+    }
+
+    const array = await window.showQuickPick(["Primitive", "Array"], {
+        placeHolder: "Decide if this rule is a primitive or an array of values.",
+        ignoreFocusOut: true,
+    });
+
+    if (array === undefined) {
+        return;
+    }
+
+    const required = await window.showQuickPick(["Required", "Optional"], {
+        placeHolder: "Decide if this rule value is required in order to pass document validation.",
+        ignoreFocusOut: true,
+    });
+
+    if (required === undefined) {
+        return;
+    }
+
+    const defaultValue = await window.showInputBox({
+        placeHolder: "Default value (press Enter to skip)",
+        prompt: "Default value for this rule type. Make sure that the default value is able to pass validation in order to avoid errors when skipping optional values.",
+        ignoreFocusOut: true,
+    });
+
+    if (defaultValue === undefined) {
+        return;
+    }
+
+    if (label && key && type) {
+        return {
+            label,
+            key,
+            type,
+            default: defaultValue,
+            array: array === "Array",
+            required: required === "Required",
+            list,
+        };
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
Fixes #20 
- Ability to set the `list`, `default` and `array` properties when creating a new collection.